### PR TITLE
make it not break on multi recipient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,10 +3,10 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-      <groupId>org.jboss</groupId>
-      <artifactId>jboss-parent</artifactId>
-      <version>39</version>
-  </parent>    
+    <groupId>org.jboss</groupId>
+    <artifactId>jboss-parent</artifactId>
+    <version>39</version>
+  </parent>
   <groupId>io.quarkus.bot</groupId>
   <artifactId>quarkus-zulip</artifactId>
   <version>1.0.0-SNAPSHOT</version>
@@ -34,7 +34,7 @@
   <dependencies>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy-jackson</artifactId>
+      <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
@@ -47,6 +47,11 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-openshift</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkiverse.ngrok</groupId>
+      <artifactId>quarkus-ngrok</artifactId>
+      <version>1.3.0</version>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
@@ -77,7 +82,6 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${compiler-plugin.version}</version>
         <configuration>
@@ -85,13 +89,11 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${surefire-plugin.version}</version>
         <configuration>
           <systemPropertyVariables>
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-            <!--suppress UnresolvedMavenProperty -->
             <maven.home>${maven.home}</maven.home>
           </systemPropertyVariables>
         </configuration>
@@ -109,7 +111,6 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
             <version>${surefire-plugin.version}</version>
             <executions>
@@ -122,7 +123,6 @@
                   <systemPropertyVariables>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
                     <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                    <!--suppress UnresolvedMavenProperty -->
                     <maven.home>${maven.home}</maven.home>
                   </systemPropertyVariables>
                 </configuration>

--- a/src/main/java/io/quarkus/bot/zulip/payload/OutgoingWebhookPayload.java
+++ b/src/main/java/io/quarkus/bot/zulip/payload/OutgoingWebhookPayload.java
@@ -2,6 +2,8 @@ package io.quarkus.bot.zulip.payload;
 
 import java.util.List;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 /**
  * This payload is defined in https://zulip.com/api/outgoing-webhooks#outgoing-webhook-format
  */
@@ -27,7 +29,7 @@ public class OutgoingWebhookPayload {
 
         public String content;
 
-        public String display_recipient;
+        public JsonNode display_recipient;
 
         public int id;
 


### PR DESCRIPTION
display_recipient is defined as :

```


display_recipient: string | (object)[]

Data on the recipient of the message; either the name of a stream or a dictionary containing basic data on the users who received the message.

```

thus in a stream you get "dev" in private rooms you get a list of individuals with more complex structure.

this is quickfix to have it at least not break. properly wanna do a smarter type safe seriailzation later.

oh. and moved to use resteasy-reactive instead :)